### PR TITLE
Feature/epmdj-2228: fixes for native agent-connector library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: dir
       - name: make lib
         working-directory: ./build/install/mingwX64
-        run: lib /def:agent_connector.def /out:agent-connector.lib
+        run: lib /def:agent_connector.def /out:agent_connector.lib
       - name: Publish
         run: |
           gradle -si publishMingwX64ZipPublicationToMavenRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,18 +24,29 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: ilammy/msvc-dev-cmd@v1
-      - name: install
+      - name: installDebug
         run: |
-          gradle installMingwX64Dist
-      - name: ls
-        working-directory: ./build/install/mingwX64
+          gradle installMingwX64DebugDist
+      - name: lsdebug
+        working-directory: ./build/install/mingwX64Debug
         run: dir
-      - name: make lib
-        working-directory: ./build/install/mingwX64
+      - name: make debug lib
+        working-directory: ./build/install/mingwX64Debug
+        run: lib /def:agent_connector.def /machine:X64 /out:agent_connector.lib
+
+      - name: installRelease
+        run: |
+          gradle installMingwX64ReleaseDist
+      - name: lsrelease
+        working-directory: ./build/install/mingwX64Release
+        run: dir
+      - name: make release lib
+        working-directory: ./build/install/mingwX64Release
         run: lib /def:agent_connector.def /machine:X64 /out:agent_connector.lib
       - name: Publish
         run: |
-          gradle -si publishMingwX64ZipPublicationToMavenRepository
+          gradle -si publishMingwX64DebugZipPublicationToMavenRepository
+          gradle -si publishMingwX64ReleaseZipPublicationToMavenRepository
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: dir
       - name: make lib
         working-directory: ./build/install/mingwX64
-        run: lib /def:agent_connector.def /out:agent_connector.lib
+        run: lib /def:agent_connector.def /machine:X64 /out:agent_connector.lib
       - name: Publish
         run: |
           gradle -si publishMingwX64ZipPublicationToMavenRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,13 +45,13 @@ kotlin {
         }
         mingwX64 {
             binaries.all { linkerOpts("-lpsapi", "-lwsock32", "-lws2_32", "-lmswsock") }
-            binaries.sharedLib(libName, setOf(DEBUG))
+            binaries.sharedLib(libName, setOf(DEBUG, RELEASE))
         }
         linuxX64 {
-            binaries.sharedLib(libName, setOf(DEBUG))
+            binaries.sharedLib(libName, setOf(DEBUG, RELEASE))
         }
         macosX64 {
-            binaries.sharedLib(libName, setOf(DEBUG))
+            binaries.sharedLib(libName, setOf(DEBUG, RELEASE))
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ configurations.all {
 
 }
 
-val libName = "agent-connector"
+val libName = "agent_connector"
 kotlin {
 
     targets {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,17 +59,27 @@ kotlin {
 
 afterEvaluate {
     val availableTarget =
-        kotlin.targets.filterIsInstance<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().filter { org.jetbrains.kotlin.konan.target.HostManager()
-            .isEnabled(it.konanTarget) }
+        kotlin.targets.filterIsInstance<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().filter {
+            org.jetbrains.kotlin.konan.target.HostManager()
+                .isEnabled(it.konanTarget)
+        }
 
     distributions {
         availableTarget.forEach {
-            val name = it.name
-            create(name) {
-                distributionBaseName.set(name)
+            val debugName = it.name + "Debug"
+            create(debugName) {
+                distributionBaseName.set(debugName)
                 contents {
-                    from(tasks.getByPath("link${libName.capitalize()}DebugShared${name.capitalize()}"))
-                    from("build/install/$name")
+                    from(tasks.getByPath("link${libName.capitalize()}DebugShared${it.name.capitalize()}"))
+                    from("build/install/$debugName")
+                }
+            }
+            val releaseName = it.name + "Release"
+            create(releaseName) {
+                distributionBaseName.set(releaseName)
+                contents {
+                    from(tasks.getByPath("link${libName.capitalize()}ReleaseShared${it.name.capitalize()}"))
+                    from("build/install/$releaseName")
                 }
             }
         }
@@ -94,9 +104,13 @@ afterEvaluate {
 
         publications {
             availableTarget.forEach {
-                create<MavenPublication>("${it.name}Zip") {
+                create<MavenPublication>("${it.name}DebugZip") {
                     artifactId = "$libName-${it.name}"
-                    artifact(tasks["${it.name}DistZip"])
+                    artifact(tasks["${it.name}DebugDistZip"])
+                }
+                create<MavenPublication>("${it.name}ReleaseZip") {
+                    artifactId = "$libName-${it.name}"
+                    artifact(tasks["${it.name}ReleaseDistZip"])
                 }
             }
         }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <libdrilldotnet_api.h>
+#include <agent_connector_api.h>
 
 
 
@@ -10,7 +10,7 @@ void xx(char* x1, char* x2){
 
 int main() {
 
-    libdrilldotnet_ExportedSymbols *ptr = libdrilldotnet_symbols();
+    agent_connector_ExportedSymbols *ptr = agent_connector_symbols();
     void (*fun)(char *, char *) = xx;
     void *function = (void *)(fun);
     initialize_agent("mysuperAgent", "localhost:8090", "1.0.0", "group", "fail",function);

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,103 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
* EPMDJ-2228: Added gradlew.bat
The start file to run building and publishing was missing in the repository. Copied from Drill4J/admin [https://github.com/Drill4J/admin/blob/develop/gradlew.bat]

* EPMDJ-2228: Renamed `agent-connector` to `agent_connector`.
Kotlin native generator anyway replaces dash (`-`) to underscore (`_`) in file names that only confuses with other names, for example `agent-connector.lib`. Let all the generated files be `agent_connector.*` from the beginning.

* EPMDJ-2228: Target platform for mingwX64 import lib must be specified: /machine:X64
Attempt to fix the import library `agent_connector.lib`. MSVC lib creates different export names for x86 and x64 machines and uses x86 option by default.

* EPMDJ-2228: Added RELEASE configurations.
(?) We will anyway need RELEASE configurations in the future. Let's see if it's possible to publish them properly. Maybe it needs additional changes in publishing(?)
